### PR TITLE
Enforce timestamped index notes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,7 +41,7 @@ Exercises with solutions:
 - **Timed**: `./scripts/create-node.sh problem-timed "Title"`
 
 ### 5. Index/MOC Notes
-Topic hubs that organize related notes:
+Topic hubs that organize related notes. These notes should be timestamped just like any other node. Use the creation script:
 - `./scripts/create-index.sh "Topic Name"`
 
 ### 6. Daily Notes
@@ -120,6 +120,7 @@ The setupfile includes common physics and math packages:
 #### Titles
 - Clear and specific
 - Include key searchable terms
+- Do not duplicate the title as a heading
 - Examples:
   ✓ "Variational Autoencoders - Latent Space Structure"
   ✗ "VAE Notes"
@@ -221,6 +222,7 @@ All nodes must have a `:ID:` property. If missing, the node won't be recognized 
 - Scripts use Emacs batch mode to ensure proper Org-Roam functionality
 - Always include `#+SETUPFILE: ../../setupfile.org` for consistency
 - Node IDs are UUIDs generated automatically
+- All note files are timestamped by the creation scripts
 
 ## Getting Started
 

--- a/notes/index/2025-06-11-11-02-51-a-guide-for-communicating-with-slipboxes.org
+++ b/notes/index/2025-06-11-11-02-51-a-guide-for-communicating-with-slipboxes.org
@@ -5,7 +5,6 @@
 #+FILETAGS: :index:
 #+SETUPFILE: ../../setupfile.org
 
-* A guide for communicating with slipboxes
 A comprehensive reference for all interactions with the Org-Roam notes management agent.
 
 * Table of Contents

--- a/scripts/create-index.sh
+++ b/scripts/create-index.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 set -euo pipefail
+
 TITLE="$1"
-SLUG=$(echo "$TITLE" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9]/-/g;s/--*/-/g;s/^-//;s/-$//')
-FILE="notes/index/${SLUG}.org"
-UUID=$(uuidgen)
-mkdir -p notes/index
-emacs --batch -l scripts/init-org-roam.el --eval "(with-temp-file \"${FILE}\" (insert \":PROPERTIES:\n:ID:       ${UUID}\n:END:\n#+TITLE: ${TITLE}\n#+FILETAGS: :index:\n#+SETUPFILE: ../../setupfile.org\n\n\"))"
-echo "Index created: $FILE"
+CONTENT="${2:-}"
+
+emacs --batch -l scripts/init-org-roam.el --eval "
+(let ((file (create-org-roam-node \"index\" \"${TITLE}\" \"${CONTENT}\")))
+  (message \"Index created: %s\" file))"


### PR DESCRIPTION
## Summary
- note creation guidelines forbid title duplication and demand timestamped index notes
- update `create-index.sh` to call the common node creation function
- rename the communication guide index note with timestamp and remove duplicate heading

## Testing
- `./scripts/check-health.sh` *(fails: emacs command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849666fadc8832bbc88f45802e53ee5