### PR TITLE
Add Smartparens notes

### DIFF
--- a/notes/concept/2025-06-14-22-08-41-smartparens-navigation.org
+++ b/notes/concept/2025-06-14-22-08-41-smartparens-navigation.org
@@ -1,0 +1,19 @@
+:PROPERTIES:
+:ID:       a34c16d6-b152-4a97-b35b-447c858d1c03
+:END:
+#+TITLE: Smartparens Navigation
+#+FILETAGS: :concept:emacs:smartparens:
+#+SETUPFILE: ../../setupfile.org
+
+* Overview
+Smartparens provides many ways to move around code without counting
+parentheses.  Basic commands jump to the start or end of a form,
+traverse nested lists, or skip entire expressions.  Symbol-based
+movement ignores delimiters completely.
+
+* Links
+- [[id:89ae4aa4-74dd-42f1-b6b6-6c4bf5df4709][Smartparens Sexp Navigation]]
+- [[id:62f42bce-6e4c-4b44-94a0-255e664b41a9][Smartparens List Traversal]]
+- [[id:0412779d-b807-4430-82ef-49930fe10e20][Smartparens Block Movement]]
+- [[id:8cdfed5f-1667-4b72-98b3-09fe86d472f1][Smartparens Symbol Navigation]]
+- [[id:4cb0ba57-c393-4586-a823-93842c96593b][Smartparens]]

--- a/notes/concept/2025-06-14-22-08-45-smartparens-manipulation.org
+++ b/notes/concept/2025-06-14-22-08-45-smartparens-manipulation.org
@@ -1,0 +1,19 @@
+:PROPERTIES:
+:ID:       d1e15c32-6bd9-4c83-92a2-54e5d8b823b9
+:END:
+#+TITLE: Smartparens Manipulation
+#+FILETAGS: :concept:emacs:smartparens:
+#+SETUPFILE: ../../setupfile.org
+
+* Overview
+Manipulation commands reshape code.  Wrapping creates new delimiters
+around a region, unwrapping removes them, slurping and barfing adjust
+list boundaries, and killing operations delete expressions while
+keeping pairs balanced.
+
+* Links
+- [[id:5a382c7e-35e2-459b-b7dc-831ed62d5956][Smartparens Wrapping]]
+- [[id:c66e57ce-7833-479e-9f96-1d2fc09d401f][Smartparens Unwrapping]]
+- [[id:05c2ea79-f4bd-4568-b9c0-9cfc21f66c09][Smartparens Slurp and Barf]]
+- [[id:77f69797-4c38-42f5-877b-38659a4bd591][Smartparens Killing Operations]]
+- [[id:4cb0ba57-c393-4586-a823-93842c96593b][Smartparens]]

--- a/notes/concept/2025-06-14-22-08-51-smartparens-pair-management.org
+++ b/notes/concept/2025-06-14-22-08-51-smartparens-pair-management.org
@@ -1,0 +1,31 @@
+:PROPERTIES:
+:ID:       5cb735cf-b65a-43cb-8766-3dff9e4d58da
+:END:
+#+TITLE: Smartparens Pair Management
+#+FILETAGS: :concept:emacs:smartparens:
+#+SETUPFILE: ../../setupfile.org
+
+* Overview
+Smartparens automatically inserts and balances pairs such as parentheses,
+brackets, braces, and quotes.  When you type an opening delimiter the
+matching closing delimiter appears and point is placed between them.
+Pair definitions can be extended for any major mode.
+
+* Example
+Typing a left bracket after =defn foo= results in the closing bracket
+being inserted automatically:
+
+#+BEGIN_SRC clojure
+(defn foo )
+          ^
+#+END_SRC
+
+becomes
+
+#+BEGIN_SRC clojure
+(defn foo [])
+           ^
+#+END_SRC
+
+* Links
+- [[id:4cb0ba57-c393-4586-a823-93842c96593b][Smartparens]]

--- a/notes/concept/2025-06-14-22-08-56-smartparens-sexp-navigation.org
+++ b/notes/concept/2025-06-14-22-08-56-smartparens-sexp-navigation.org
@@ -1,0 +1,25 @@
+:PROPERTIES:
+:ID:       89ae4aa4-74dd-42f1-b6b6-6c4bf5df4709
+:END:
+#+TITLE: Smartparens Sexp Navigation
+#+FILETAGS: :concept:emacs:smartparens:
+#+SETUPFILE: ../../setupfile.org
+
+* Concept
+`sp-beginning-of-sexp` moves point to the start of the current
+expression while `sp-end-of-sexp` jumps to its end.  Useful for
+quickly selecting entire forms.
+
+* Example
+Starting from the middle of a string:
+
+#+BEGIN_SRC clojure
+(let [x "foo bar baz ... blah"]) 
+                        ^
+#+END_SRC
+
+`sp-beginning-of-sexp` moves to the start of the string and
+`sp-end-of-sexp` moves to the closing quote.
+
+* Links
+- [[id:a34c16d6-b152-4a97-b35b-447c858d1c03][Smartparens Navigation]]

--- a/notes/concept/2025-06-14-22-09-01-smartparens-list-traversal.org
+++ b/notes/concept/2025-06-14-22-09-01-smartparens-list-traversal.org
@@ -1,0 +1,38 @@
+:PROPERTIES:
+:ID:       62f42bce-6e4c-4b44-94a0-255e664b41a9
+:END:
+#+TITLE: Smartparens List Traversal
+#+FILETAGS: :concept:emacs:smartparens:
+#+SETUPFILE: ../../setupfile.org
+
+* Concept
+`sp-down-sexp`, `sp-up-sexp`, `sp-backward-down-sexp` and
+`sp-backward-up-sexp` move vertically through nested lists.
+They let you descend into a list or ascend back to the surrounding
+form without counting parentheses.
+
+* Examples
+Move from a function call into its first argument:
+
+#+BEGIN_SRC emacs-lisp
+(defun format-date (format)
+  (let ((system-time-locale "en_US.UTF-8"))
+    (insert (format-time-string format)))) ^
+#+END_SRC
+
+Running `sp-down-sexp` positions point at =insert= inside the call.
+
+Move out of an expression with `sp-up-sexp`:
+
+#+BEGIN_SRC clojure
+(str "foo" "bar baz qux")
+    ^
+#+END_SRC
+
+After `sp-up-sexp` point is placed after the closing parenthesis.
+
+Use `sp-backward-down-sexp` and `sp-backward-up-sexp` to navigate in
+the opposite direction when starting inside a list.
+
+* Links
+- [[id:a34c16d6-b152-4a97-b35b-447c858d1c03][Smartparens Navigation]]

--- a/notes/concept/2025-06-14-22-09-05-smartparens-block-movement.org
+++ b/notes/concept/2025-06-14-22-09-05-smartparens-block-movement.org
@@ -1,0 +1,31 @@
+:PROPERTIES:
+:ID:       0412779d-b807-4430-82ef-49930fe10e20
+:END:
+#+TITLE: Smartparens Block Movement
+#+FILETAGS: :concept:emacs:smartparens:
+#+SETUPFILE: ../../setupfile.org
+
+* Concept
+`sp-forward-sexp` and `sp-backward-sexp` jump over entire expressions
+at the current nesting level.  They are useful for quickly moving
+across arguments in a list.
+
+* Example
+Starting inside a =require= form:
+
+#+BEGIN_SRC clojure
+(:require [clojure.string :as s])
+          ^
+#+END_SRC
+
+`sp-forward-sexp` moves point after the closing bracket:
+
+#+BEGIN_SRC clojure
+(:require [clojure.string :as s])
+                                ^
+#+END_SRC
+
+`sp-backward-sexp` moves back to the opening bracket.
+
+* Links
+- [[id:a34c16d6-b152-4a97-b35b-447c858d1c03][Smartparens Navigation]]

--- a/notes/concept/2025-06-14-22-09-10-smartparens-symbol-navigation.org
+++ b/notes/concept/2025-06-14-22-09-10-smartparens-symbol-navigation.org
@@ -1,0 +1,25 @@
+:PROPERTIES:
+:ID:       8cdfed5f-1667-4b72-98b3-09fe86d472f1
+:END:
+#+TITLE: Smartparens Symbol Navigation
+#+FILETAGS: :concept:emacs:smartparens:
+#+SETUPFILE: ../../setupfile.org
+
+* Concept
+`sp-forward-symbol` and `sp-backward-symbol` skip over symbols while
+ignoring surrounding delimiters.  This provides free-form movement
+within expressions.
+
+* Example
+Given a Clojure function:
+
+#+BEGIN_SRC clojure
+(defn blah [] (let [x 0 y 1] (+ x 1)))
+               ^
+#+END_SRC
+
+`sp-backward-symbol` jumps to the previous symbol =blah= while
+`sp-forward-symbol` from the =]= goes just after =(let=.
+
+* Links
+- [[id:a34c16d6-b152-4a97-b35b-447c858d1c03][Smartparens Navigation]]

--- a/notes/concept/2025-06-14-22-09-15-smartparens-wrapping.org
+++ b/notes/concept/2025-06-14-22-09-15-smartparens-wrapping.org
@@ -1,0 +1,32 @@
+:PROPERTIES:
+:ID:       5a382c7e-35e2-459b-b7dc-831ed62d5956
+:END:
+#+TITLE: Smartparens Wrapping
+#+FILETAGS: :concept:emacs:smartparens:
+#+SETUPFILE: ../../setupfile.org
+
+* Concept
+`sp-wrap-with-pair` surrounds the active region or the next expression
+with matching delimiters.  Smartparens also allows defining custom
+wrappers for common pairs.
+
+* Example
+Starting with a variable:
+
+#+BEGIN_SRC javascript
+var mods = "vars";
+           ^
+#+END_SRC
+
+Activate the region and press =[= to produce:
+
+#+BEGIN_SRC javascript
+var mods = ["vars"];
+            ^
+#+END_SRC
+
+Custom wrapper functions can be created with the `def-pairs` macro to
+bind keys like =C-c [= for brackets.
+
+* Links
+- [[id:d1e15c32-6bd9-4c83-92a2-54e5d8b823b9][Smartparens Manipulation]]

--- a/notes/concept/2025-06-14-22-09-19-smartparens-unwrapping.org
+++ b/notes/concept/2025-06-14-22-09-19-smartparens-unwrapping.org
@@ -1,0 +1,32 @@
+:PROPERTIES:
+:ID:       c66e57ce-7833-479e-9f96-1d2fc09d401f
+:END:
+#+TITLE: Smartparens Unwrapping
+#+FILETAGS: :concept:emacs:smartparens:
+#+SETUPFILE: ../../setupfile.org
+
+* Concept
+`sp-backward-unwrap-sexp` removes the nearest enclosing delimiters on
+the left while `sp-unwrap-sexp` removes those on the right.  This is
+handy for restructuring code without deleting characters manually.
+
+* Example
+Unwrap the outer call:
+
+#+BEGIN_SRC clojure
+(foo (bar x y z))
+     ^
+#+END_SRC
+
+Executing `sp-backward-unwrap-sexp` yields:
+
+#+BEGIN_SRC clojure
+foo (bar x y z)
+    ^
+#+END_SRC
+
+Running `sp-unwrap-sexp` at the same point would unwrap the inner
+=bar= expression instead.
+
+* Links
+- [[id:d1e15c32-6bd9-4c83-92a2-54e5d8b823b9][Smartparens Manipulation]]

--- a/notes/concept/2025-06-14-22-09-24-smartparens-slurp-and-barf.org
+++ b/notes/concept/2025-06-14-22-09-24-smartparens-slurp-and-barf.org
@@ -1,0 +1,48 @@
+:PROPERTIES:
+:ID:       05c2ea79-f4bd-4568-b9c0-9cfc21f66c09
+:END:
+#+TITLE: Smartparens Slurp and Barf
+#+FILETAGS: :concept:emacs:smartparens:
+#+SETUPFILE: ../../setupfile.org
+
+* Concept
+Slurping expands a list to include adjacent expressions while barfing
+expels elements from a list.  The commands are `sp-forward-slurp-sexp`,
+`sp-forward-barf-sexp`, `sp-backward-slurp-sexp`, and
+`sp-backward-barf-sexp`.
+
+* Example
+Forward slurp and barf:
+
+#+BEGIN_SRC clojure
+[foo bar] baz
+        ^
+#+END_SRC
+
+`sp-forward-slurp-sexp` results in:
+
+#+BEGIN_SRC clojure
+[foo bar baz]
+        ^
+#+END_SRC
+
+`sp-forward-barf-sexp` would revert to the original form.
+
+Backward slurp and barf:
+
+#+BEGIN_SRC clojure
+blah [foo bar]
+             ^
+#+END_SRC
+
+`sp-backward-slurp-sexp` gives:
+
+#+BEGIN_SRC clojure
+[blah foo bar]
+             ^
+#+END_SRC
+
+`sp-backward-barf-sexp` removes =blah= again.
+
+* Links
+- [[id:d1e15c32-6bd9-4c83-92a2-54e5d8b823b9][Smartparens Manipulation]]

--- a/notes/concept/2025-06-14-22-09-29-smartparens-killing-operations.org
+++ b/notes/concept/2025-06-14-22-09-29-smartparens-killing-operations.org
@@ -1,0 +1,50 @@
+:PROPERTIES:
+:ID:       77f69797-4c38-42f5-877b-38659a4bd591
+:END:
+#+TITLE: Smartparens Killing Operations
+#+FILETAGS: :concept:emacs:smartparens:
+#+SETUPFILE: ../../setupfile.org
+
+* Concept
+`sp-kill-sexp`, `sp-backward-kill-sexp` and `sp-kill-hybrid-sexp` delete
+expressions while keeping surrounding pairs balanced.
+
+* Example
+Kill a single expression:
+
+#+BEGIN_SRC clojure
+(let [x "xxx" y "y yy yyy" z 0])
+               ^
+#+END_SRC
+
+`sp-kill-sexp` removes the string producing:
+
+#+BEGIN_SRC clojure
+(let [x "xxx" y z 0])
+               ^
+#+END_SRC
+
+`sp-kill-hybrid-sexp` at the same spot kills the string and the rest of
+the line, leaving:
+
+#+BEGIN_SRC clojure
+(let [x "xxx" y])
+               ^
+#+END_SRC
+
+Backward killing deletes the previous expression:
+
+#+BEGIN_SRC clojure
+(:require [clojure.string :as s])
+                                ^
+#+END_SRC
+
+`sp-backward-kill-sexp` results in:
+
+#+BEGIN_SRC clojure
+(:require )
+          ^
+#+END_SRC
+
+* Links
+- [[id:d1e15c32-6bd9-4c83-92a2-54e5d8b823b9][Smartparens Manipulation]]

--- a/notes/concept/2025-06-14-22-09-34-smartparens-key-bindings.org
+++ b/notes/concept/2025-06-14-22-09-34-smartparens-key-bindings.org
@@ -1,0 +1,72 @@
+:PROPERTIES:
+:ID:       b52f5ce9-b2fd-4be9-851d-56880f12b33f
+:END:
+#+TITLE: Smartparens Key Bindings
+#+FILETAGS: :concept:emacs:smartparens:
+#+SETUPFILE: ../../setupfile.org
+
+* Reference
+Below is the configuration snippet from the article that binds common
+Smartparens commands.
+
+#+BEGIN_SRC emacs-lisp
+(defmacro def-pairs (pairs)
+  "Define functions for pairing. PAIRS is an alist of (NAME . STRING)
+conses, where NAME is the function name that will be created and
+STRING is a single-character string that marks the opening character."
+  `(progn
+     ,@(loop for (key . val) in pairs
+             collect
+             `(defun ,(read (concat "wrap-with-" (prin1-to-string key) "s"))
+                  (&optional arg)
+                (interactive "p")
+                (sp-wrap-with-pair ,val)))))
+
+(def-pairs ((paren . "(")
+            (bracket . "[")
+            (brace . "{")
+            (single-quote . "'")
+            (double-quote . "\"")
+            (back-quote . "`")))
+
+(bind-keys
+ :map smartparens-mode-map
+ ("C-M-a" . sp-beginning-of-sexp)
+ ("C-M-e" . sp-end-of-sexp)
+ ("C-<down>" . sp-down-sexp)
+ ("C-<up>"   . sp-up-sexp)
+ ("M-<down>" . sp-backward-down-sexp)
+ ("M-<up>"   . sp-backward-up-sexp)
+ ("C-M-f" . sp-forward-sexp)
+ ("C-M-b" . sp-backward-sexp)
+ ("C-M-n" . sp-next-sexp)
+ ("C-M-p" . sp-previous-sexp)
+ ("C-S-f" . sp-forward-symbol)
+ ("C-S-b" . sp-backward-symbol)
+ ("C-<right>" . sp-forward-slurp-sexp)
+ ("M-<right>" . sp-forward-barf-sexp)
+ ("C-<left>"  . sp-backward-slurp-sexp)
+ ("M-<left>"  . sp-backward-barf-sexp)
+ ("C-M-t" . sp-transpose-sexp)
+ ("C-M-k" . sp-kill-sexp)
+ ("C-k"   . sp-kill-hybrid-sexp)
+ ("M-k"   . sp-backward-kill-sexp)
+ ("C-M-w" . sp-copy-sexp)
+ ("C-M-d" . delete-sexp)
+ ("M-<backspace>" . backward-kill-word)
+ ("C-<backspace>" . sp-backward-kill-word)
+ ([remap sp-backward-kill-word] . backward-kill-word)
+ ("M-[" . sp-backward-unwrap-sexp)
+ ("M-]" . sp-unwrap-sexp)
+ ("C-x C-t" . sp-transpose-hybrid-sexp)
+ ("C-c ("  . wrap-with-parens)
+ ("C-c ["  . wrap-with-brackets)
+ ("C-c {"  . wrap-with-braces)
+ ("C-c '"  . wrap-with-single-quotes)
+ ("C-c \"" . wrap-with-double-quotes)
+ ("C-c _"  . wrap-with-underscores)
+ ("C-c `"  . wrap-with-back-quotes))
+#+END_SRC
+
+* Links
+- [[id:4cb0ba57-c393-4586-a823-93842c96593b][Smartparens]]

--- a/notes/index/2025-06-14-22-08-34-smartparens.org
+++ b/notes/index/2025-06-14-22-08-34-smartparens.org
@@ -1,0 +1,17 @@
+:PROPERTIES:
+:ID:       4cb0ba57-c393-4586-a823-93842c96593b
+:END:
+#+TITLE: Smartparens
+#+FILETAGS: :index:emacs:smartparens:
+#+SETUPFILE: ../../setupfile.org
+
+* Overview
+Smartparens is an Emacs package for structural editing and automatic
+pair management.  This index links to notes on navigation and
+manipulation techniques as well as installation and key bindings.
+
+* Links
+- [[id:a34c16d6-b152-4a97-b35b-447c858d1c03][Smartparens Navigation]]
+- [[id:d1e15c32-6bd9-4c83-92a2-54e5d8b823b9][Smartparens Manipulation]]
+- [[id:5cb735cf-b65a-43cb-8766-3dff9e4d58da][Smartparens Pair Management]]
+- [[id:b52f5ce9-b2fd-4be9-851d-56880f12b33f][Smartparens Key Bindings]]


### PR DESCRIPTION
## Summary
- add an index note for Smartparens with links
- expand pair management with automatic insertion example
- detail navigation techniques and manipulation operations
- include keybinding configuration snippet

## Testing
- `./scripts/check-health.sh`
- `./scripts/sync-db.sh` *(fails: emacs not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684df1b914dc832b80db11eed3a910e2